### PR TITLE
update: bump the client version from v18 to v19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_google_ads"],
     install_requires=[
-        "google-ads",
+        "google-ads==25.2.0",
         "requests",
         "singer-python",
     ],

--- a/tap_google_ads/streams/ad_group_metrics.py
+++ b/tap_google_ads/streams/ad_group_metrics.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -28,7 +28,7 @@ class AdGroupMetrics(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/ad_group_metrics_conversions.py
+++ b/tap_google_ads/streams/ad_group_metrics_conversions.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -29,7 +29,7 @@ class AdGroupMetricsConversions(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/ad_metrics.py
+++ b/tap_google_ads/streams/ad_metrics.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -28,7 +28,7 @@ class AdMetrics(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/ad_metrics_conversions.py
+++ b/tap_google_ads/streams/ad_metrics_conversions.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -29,7 +29,7 @@ class AdMetricsConversions(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/ads.py
+++ b/tap_google_ads/streams/ads.py
@@ -371,4 +371,4 @@ class Ads(Base):
                     "customer_id": row.customer.id,
                 }
 
-            time.sleep(5)
+            time.sleep(1)

--- a/tap_google_ads/streams/base.py
+++ b/tap_google_ads/streams/base.py
@@ -47,7 +47,7 @@ class Base:
 
     def get_tap_data(self, config, state):
         client_config = {key: value for key, value in config.items() if key in CLIENT_CONFIG_KEYS}
-        client = GoogleAdsClient.load_from_dict(config_dict=client_config, version="v18")
+        client = GoogleAdsClient.load_from_dict(config_dict=client_config, version="v19")
         service = client.get_service("GoogleAdsService")
 
         for customer_id in config["customer_ids"]:
@@ -77,7 +77,7 @@ class Incremental(Base):
       self._state = state.copy()
 
       client_config = {key: value for key, value in config.items() if key in CLIENT_CONFIG_KEYS}
-      client = GoogleAdsClient.load_from_dict(config_dict=client_config, version="v18")
+      client = GoogleAdsClient.load_from_dict(config_dict=client_config, version="v19")
       service = client.get_service("GoogleAdsService")
 
       for customer_id in config["customer_ids"]:

--- a/tap_google_ads/streams/base.py
+++ b/tap_google_ads/streams/base.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
 
@@ -71,7 +71,7 @@ class Incremental(Base):
         return "INCREMENTAL"
 
     def get_tap_data(self, config, state):
-      today = datetime.utcnow().date().isoformat()
+      today = datetime.now(timezone.utc).date().isoformat()
       self._start_date = config.get("start_date", today)
       self._backoff_seconds = config.get("rate_limit_backoff_seconds", DEFAULT_BACKOFF_SECONDS)
       self._state = state.copy()

--- a/tap_google_ads/streams/campaign_metrics.py
+++ b/tap_google_ads/streams/campaign_metrics.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -29,7 +29,7 @@ class CampaignMetrics(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/campaign_metrics_conversions.py
+++ b/tap_google_ads/streams/campaign_metrics_conversions.py
@@ -2,7 +2,7 @@ import singer
 import json
 import time
 from singer import metadata
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
@@ -29,7 +29,7 @@ class CampaignMetricsConversions(Incremental):
         return "INCREMENTAL"
 
     def gen_records(self, config, service, customer_id):
-        today = datetime.utcnow().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         state_date = self._state.get(customer_id, self._start_date)
         after = max(self._start_date, state_date)
         start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")

--- a/tap_google_ads/streams/campaigns.py
+++ b/tap_google_ads/streams/campaigns.py
@@ -42,7 +42,6 @@ class Campaigns(Base):
                 campaign.campaign_budget,
                 campaign.commission.commission_rate_micros,
                 campaign.dynamic_search_ads_setting.domain_name,
-                campaign.dynamic_search_ads_setting.feeds,
                 campaign.dynamic_search_ads_setting.language_code,
                 campaign.dynamic_search_ads_setting.use_supplied_urls_only,
                 campaign.end_date,
@@ -125,7 +124,7 @@ class Campaigns(Base):
                     },
                     "dynamic_search_ads_setting": {
                         "domain_name": c.dynamic_search_ads_setting.domain_name,
-                        "feeds": list(c.dynamic_search_ads_setting.feeds),
+                        "feeds": list(),
                         "language_code": c.dynamic_search_ads_setting.language_code,
                         "use_supplied_urls_only": c.dynamic_search_ads_setting.use_supplied_urls_only,
                     },


### PR DESCRIPTION
- replace `datetime.utcnow()` with `datetime.now(timezone.utc)`.
- bump Google Ads client version to v19.
- pin Google Ads Python library version to `25.2.0`.
- drop components related to `CampaignFeed`. Check [this reference](https://developers.google.com/google-ads/api/docs/upgrade#v18-v19) and verify it with [query validator](https://developers.google.com/google-ads/api/fields/v19/query_validator). 