### PR TITLE
feat: add support of PMAX metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="tap-google-ads",
-    version="0.2.0",
+    version="0.2.1",
     description="Singer.io tap for extracting data from Google Ads API.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tap_google_ads/schemas/pmax_metrics.json
+++ b/tap_google_ads/schemas/pmax_metrics.json
@@ -1,0 +1,57 @@
+{
+  "type": "object",
+  "properties": {
+    "campaign_id": {
+      "type": "integer"
+    },
+    "asset_id": {
+      "type": ["integer", "null"]
+    },
+    "asset_name": {
+      "type": ["string", "null"]
+    },
+    "asset_type": {
+      "type": ["string", "null"]
+    },
+    "advertising_channel_type": {
+      "type": ["string", "null"]
+    },
+    "ad_network_type": {
+      "type": ["string", "null"]
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "device": {
+      "type": ["string", "null"]
+    },
+    "all_conversions": {
+      "type": ["number", "null"]
+    },
+    "clicks": {
+      "type": ["integer", "null"]
+    },
+    "conversions": {
+      "type": ["number", "null"]
+    },
+    "cost_micros": {
+      "type": ["number", "null"]
+    },
+    "cross_device_conversions": {
+      "type": ["number", "null"]
+    },
+    "engagements": {
+      "type": ["number", "null"]
+    },
+    "impressions": {
+      "type": ["integer", "null"]
+    },
+    "interactions": {
+      "type": ["integer", "null"]
+    },
+    "customer_id": {
+      "type": "number"
+    }
+  }
+}

--- a/tap_google_ads/schemas/pmax_metrics_conversions.json
+++ b/tap_google_ads/schemas/pmax_metrics_conversions.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+  "properties": {
+    "campaign_id": {
+      "type": "integer"
+    },
+    "asset_id": {
+      "type": ["integer", "null"]
+    },
+    "asset_name": {
+      "type": ["string", "null"]
+    },
+    "asset_type": {
+      "type": ["string", "null"]
+    },
+    "advertising_channel_type": {
+      "type": ["string", "null"]
+    },
+    "ad_network_type": {
+      "type": ["string", "null"]
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "device": {
+      "type": ["string", "null"]
+    },
+    "conversion_action": {
+      "type": ["string", "null"]
+    },
+    "conversion_action_name": {
+      "type": ["string", "null"]
+    },
+    "all_conversions": {
+      "type": ["number", "null"]
+    },
+    "all_conversions_value": {
+      "type": ["number", "null"]
+    },
+    "conversions": {
+      "type": ["number", "null"]
+    },
+    "conversions_value": {
+      "type": ["number", "null"]
+    },
+    "cross_device_conversions": {
+      "type": ["number", "null"]
+    },
+    "customer_id": {
+      "type": "number"
+    }
+  }
+}

--- a/tap_google_ads/streams/__init__.py
+++ b/tap_google_ads/streams/__init__.py
@@ -7,6 +7,8 @@ from .ad_group_metrics_conversions import AdGroupMetricsConversions
 from .ads import Ads
 from .ad_metrics import AdMetrics
 from .ad_metrics_conversions import AdMetricsConversions
+from .pmax_metrics import PmaxMetrics
+from .pmax_metrics_conversions import PmaxMetricsConversions
 
 def create_stream(stream_id):
     if stream_id == "campaigns":
@@ -27,5 +29,9 @@ def create_stream(stream_id):
         return AdMetrics()
     elif stream_id == "ad_metrics_conversions":
         return AdMetricsConversions()
+    elif stream_id == "pmax_metrics":
+        return PmaxMetrics()
+    elif stream_id == "pmax_metrics_conversions":
+        return PmaxMetricsConversions()
 
     assert False, f"Unsupported stream: {stream_id}"

--- a/tap_google_ads/streams/pmax_metrics.py
+++ b/tap_google_ads/streams/pmax_metrics.py
@@ -1,0 +1,91 @@
+import singer
+from datetime import datetime, timedelta, timezone
+from dateutil.parser import parse
+from .base import Incremental
+LOOKBACK_WINDOW = 90
+
+LOGGER = singer.get_logger()
+
+class PmaxMetrics(Incremental):
+    @property
+    def name(self):
+        return "pmax_metrics"
+
+    @property
+    def key_properties(self):
+        return ["campaign_id", "asset_id", "ad_network_type", "date", "device"]
+
+    @property
+    def replication_key(self):
+        return "date"
+
+    @property
+    def replication_method(self):
+        return "INCREMENTAL"
+
+    def gen_records(self, config, service, customer_id):
+        today = datetime.now(timezone.utc).date().isoformat()
+        state_date = self._state.get(customer_id, self._start_date)
+        after = max(self._start_date, state_date)
+        start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")
+        end_date = config.get("end_date", today)
+        end = min(parse(after) + timedelta(days=365), parse(end_date)).strftime("%Y-%m-%d")
+        max_rep_key = after
+
+        LOGGER.info(f"{self.name}:{start} to {end}")
+
+        query = f"""
+            SELECT
+                campaign.id,
+                campaign.advertising_channel_type,
+                asset.id,
+                asset.name,
+                asset.type,
+                segments.ad_network_type,
+                segments.date,
+                segments.device,
+                metrics.all_conversions,
+                metrics.clicks,
+                metrics.conversions,
+                metrics.cost_micros,
+                metrics.cross_device_conversions,
+                metrics.engagements,
+                metrics.impressions,
+                metrics.interactions
+            FROM campaign_asset
+            WHERE campaign.advertising_channel_type = PERFORMANCE_MAX AND segments.date >= '{start}' AND segments.date <= '{end}'
+            """
+        resp = service.search_stream(customer_id=customer_id, query=query)
+
+        for batch in resp:
+            for row in batch.results:
+                a = row.asset
+                s = row.segments
+                c = row.campaign
+                m = row.metrics
+
+                rep_key = s.date
+                if rep_key and rep_key > max_rep_key:
+                    max_rep_key = rep_key
+
+                yield {
+                    "campaign_id": c.id,
+                    "asset_id": a.id,
+                    "asset_name": a.name,
+                    "asset_type": a.type_,
+                    "advertising_channel_type": c.advertising_channel_type,
+                    "ad_network_type": s.ad_network_type,
+                    "date": s.date,
+                    "device": s.device,
+                    "all_conversions": m.all_conversions,
+                    "clicks": m.clicks,
+                    "conversions": m.conversions,
+                    "cost_micros": m.cost_micros,
+                    "cross_device_conversions": m.cross_device_conversions,
+                    "engagements": m.engagements,
+                    "impressions": m.impressions,
+                    "interactions": m.interactions,
+                    "customer_id": customer_id,
+                }
+
+        self._state[customer_id] = max_rep_key

--- a/tap_google_ads/streams/pmax_metrics_conversions.py
+++ b/tap_google_ads/streams/pmax_metrics_conversions.py
@@ -1,0 +1,89 @@
+import singer
+from datetime import datetime, timedelta, timezone
+from dateutil.parser import parse
+from .base import Incremental
+LOOKBACK_WINDOW = 90
+
+LOGGER = singer.get_logger()
+
+class PmaxMetricsConversions(Incremental):
+    @property
+    def name(self):
+        return "pmax_metrics_conversions"
+
+    @property
+    def key_properties(self):
+        return ["campaign_id", "asset_id", "ad_network_type", "date", "device", "conversion_action", "conversion_action_name"]
+
+    @property
+    def replication_key(self):
+        return "date"
+
+    @property
+    def replication_method(self):
+        return "INCREMENTAL"
+
+    def gen_records(self, config, service, customer_id):
+        today = datetime.now(timezone.utc).date().isoformat()
+        state_date = self._state.get(customer_id, self._start_date)
+        after = max(self._start_date, state_date)
+        start = (parse(after) - timedelta(days=LOOKBACK_WINDOW)).strftime("%Y-%m-%d")
+        end_date = config.get("end_date", today)
+        end = min(parse(after) + timedelta(days=365), parse(end_date)).strftime("%Y-%m-%d")
+        max_rep_key = after
+
+        LOGGER.info(f"{self.name}:{start} to {end}")
+
+        query = f"""
+            SELECT
+                campaign.id,
+                campaign.advertising_channel_type,
+                asset.id,
+                asset.name,
+                asset.type,
+                segments.ad_network_type,
+                segments.date,
+                segments.device,
+                segments.conversion_action,
+                segments.conversion_action_name,
+                metrics.all_conversions,
+                metrics.all_conversions_value,
+                metrics.conversions,
+                metrics.conversions_value,
+                metrics.cross_device_conversions
+            FROM campaign_asset
+            WHERE campaign.advertising_channel_type = PERFORMANCE_MAX AND segments.date >= '{start}' AND segments.date <= '{end}'
+            """
+        resp = service.search_stream(customer_id=customer_id, query=query)
+
+        for batch in resp:
+            for row in batch.results:
+                a = row.asset
+                s = row.segments
+                c = row.campaign
+                m = row.metrics
+
+                rep_key = s.date
+                if rep_key and rep_key > max_rep_key:
+                    max_rep_key = rep_key
+
+                yield {
+                    "campaign_id": c.id,
+                    "asset_id": a.id,
+                    "asset_name": a.name,
+                    "asset_type": a.type_,
+                    "advertising_channel_type": c.advertising_channel_type,
+                    "ad_network_type": s.ad_network_type,
+                    "date": s.date,
+                    "device": s.device,
+                    "conversion_action": s.conversion_action,
+                    "conversion_action_name": s.conversion_action_name,
+                    "all_conversions": m.all_conversions,
+                    "all_conversions_value": m.all_conversions_value,
+                    "conversions": m.conversions,
+                    "conversions_value": m.conversions_value,
+                    "cross_device_conversions": m.cross_device_conversions,
+                    "customer_id": customer_id,
+                }
+
+        self._state[customer_id] = max_rep_key


### PR DESCRIPTION
It might not be the best solution to approach this, but we will use it. Essentially, our goal is to get asset level info for PMAX campaigns. Breaking existing pipeline/granularity is not that acceptable. Thus, we create two new streams for PMAX conversions and engagements, respectively. 