### PR TITLE
Fix: pin singer-python to 6.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "google-ads==30.1.0",
         "requests",
-        "singer-python",
+        "singer-python==6.1.1",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
Might be tied with Python version tho. 
When using Python version 3.11, pip will install singer-python==6.8.0 and that somehow causes troubles. 
If the issue occurs once more, we need to consider add stricter constraints like `singer.io/tap-google-ads`