### PR TITLE
Fix: pin selected libraries version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     install_requires=[
         "google-ads==30.1.0",
         "requests",
-        "singer-python==6.1.1",
+        "singer-python",
+        "protobuf==6.33.6",
     ],
     entry_points="""
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "requests",
         "singer-python",
         "protobuf==6.33.6",
+        "grpcio-status==1.73.1",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
It seems that we might meet unexpected empty lines for singer's standard I/O pipe. 
Adding extra constraints of libraries to see if we can resolve the issue. 
Loosen constraint on `singer-python`. (Might not be related to this issue)